### PR TITLE
Trimming nextLine could lead to erroneous results

### DIFF
--- a/diffparser/src/main/java/org/wickedsource/diffparser/unified/ResizingParseWindow.java
+++ b/diffparser/src/main/java/org/wickedsource/diffparser/unified/ResizingParseWindow.java
@@ -71,7 +71,6 @@ public class ResizingParseWindow implements ParseWindow {
             for (int i = 0; i < numberOfLinesToLoad; i++) {
                 String nextLine = getNextLine();
                 if (nextLine != null) {
-                    nextLine = nextLine.trim();
                     lineQueue.addLast(nextLine);
                 } else {
                     throw new IndexOutOfBoundsException("End of stream has been reached!");
@@ -90,7 +89,6 @@ public class ResizingParseWindow implements ParseWindow {
             if (lineQueue.isEmpty()) {
                 String nextLine = getNextLine();
                 if (nextLine != null) {
-                    nextLine = nextLine.trim();
                     lineQueue.addLast(nextLine);
                 }
                 return nextLine;


### PR DESCRIPTION
nextLine.trim() could lead to erroneous results. For example, when a line (which was not changed) starts with - or +. In unified diff, a space is added in front of such a line to distinguish them from changed lines. This distinguishing space is removed by trimming nextLine. This behavior could for example be observed by MySQL dump files created with mysqldump.
