### PR TITLE
Allow optional hunk from/to range line count.

### DIFF
--- a/diffparser/src/main/java/org/wickedsource/diffparser/api/UnifiedDiffParser.java
+++ b/diffparser/src/main/java/org/wickedsource/diffparser/api/UnifiedDiffParser.java
@@ -115,15 +115,15 @@ public class UnifiedDiffParser implements DiffParser {
     }
 
     private void parseHunkStart(Diff currentDiff, String currentLine) {
-        Pattern pattern = Pattern.compile("^.*-([0-9]+),([0-9]+) \\+([0-9]+),([0-9]+).*$");
+        Pattern pattern = Pattern.compile("^.*-([0-9]+)(?:,([0-9]+))? \\+([0-9]+)(?:,([0-9]+))?.*$");
         Matcher matcher = pattern.matcher(currentLine);
         if (matcher.matches()) {
             String range1Start = matcher.group(1);
-            String range1End = matcher.group(2);
+            String range1End = (matcher.group(2) != null) ? matcher.group(2) : "1";
             Range fromRange = new Range(Integer.valueOf(range1Start), Integer.valueOf(range1End));
 
             String range2Start = matcher.group(3);
-            String range2End = matcher.group(4);
+            String range2End = (matcher.group(4) != null) ? matcher.group(4) : "1";
             Range toRange = new Range(Integer.valueOf(range2Start), Integer.valueOf(range2End));
 
             Hunk hunk = new Hunk();

--- a/diffparser/src/test/java/org/wickedsource/diffparser/unified/UnifiedDiffParserTest.java
+++ b/diffparser/src/test/java/org/wickedsource/diffparser/unified/UnifiedDiffParserTest.java
@@ -50,4 +50,31 @@ public class UnifiedDiffParserTest {
         Assert.assertEquals(Line.LineType.NEUTRAL, lines.get(5).getLineType());
 
     }
+
+    @Test
+    public void testParse_WhenHunkRangeLineCountNotSpecified_ShouldSetHunkRangeLineCountToOne() throws Exception {
+        // given
+        DiffParser parser = new UnifiedDiffParser();
+        String in = ""
+            + "--- from	2015-12-21 17:53:29.082877088 -0500\n"
+            + "+++ to	2015-12-21 08:41:52.663714666 -0500\n"
+            + "@@ -10 +10 @@\n"
+            + "-from\n"
+            + "+to\n"
+            + "\n";
+
+        // when
+        List<Diff> diffs = parser.parse(in.getBytes());
+
+        // then
+        Assert.assertNotNull(diffs);
+        Assert.assertEquals(1, diffs.size());
+
+        Diff diff1 = diffs.get(0);
+        Assert.assertEquals(1, diff1.getHunks().size());
+
+        Hunk hunk1 = diff1.getHunks().get(0);
+        Assert.assertEquals(1, hunk1.getFromFileRange().getLineEnd());
+        Assert.assertEquals(1, hunk1.getToFileRange().getLineEnd());
+    }
 }


### PR DESCRIPTION
Per [1], in many versions of GNU diff, each range can omit the comma and trailing value `s` (where `s` is the range line count), in which case `s` defaults to 1.  See also [2].

[1] https://en.wikipedia.org/wiki/Diff_utility#Unified_format
[2] http://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html