### PR TITLE
Rename hunk range "line end" to "line count".

### DIFF
--- a/diffparser/src/main/java/org/wickedsource/diffparser/api/UnifiedDiffParser.java
+++ b/diffparser/src/main/java/org/wickedsource/diffparser/api/UnifiedDiffParser.java
@@ -119,12 +119,12 @@ public class UnifiedDiffParser implements DiffParser {
         Matcher matcher = pattern.matcher(currentLine);
         if (matcher.matches()) {
             String range1Start = matcher.group(1);
-            String range1End = matcher.group(2);
-            Range fromRange = new Range(Integer.valueOf(range1Start), Integer.valueOf(range1End));
+            String range1Count = matcher.group(2);
+            Range fromRange = new Range(Integer.valueOf(range1Start), Integer.valueOf(range1Count));
 
             String range2Start = matcher.group(3);
-            String range2End = matcher.group(4);
-            Range toRange = new Range(Integer.valueOf(range2Start), Integer.valueOf(range2End));
+            String range2Count = matcher.group(4);
+            Range toRange = new Range(Integer.valueOf(range2Start), Integer.valueOf(range2Count));
 
             Hunk hunk = new Hunk();
             hunk.setFromFileRange(fromRange);

--- a/diffparser/src/main/java/org/wickedsource/diffparser/api/model/Range.java
+++ b/diffparser/src/main/java/org/wickedsource/diffparser/api/model/Range.java
@@ -24,11 +24,11 @@ public class Range {
 
     private final int lineStart;
 
-    private final int lineEnd;
+    private final int lineCount;
 
-    public Range(int lineStart, int lineEnd) {
+    public Range(int lineStart, int lineCount) {
         this.lineStart = lineStart;
-        this.lineEnd = lineEnd;
+        this.lineCount = lineCount;
     }
 
     /**
@@ -41,12 +41,12 @@ public class Range {
     }
 
     /**
-     * The line number at which this range ends (inclusive).
+     * The count of lines in this range.
      *
-     * @return the line number at which this range ends.
+     * @return the count of lines in this range.
      */
-    public int getLineEnd() {
-        return lineEnd;
+    public int getLineCount() {
+        return lineCount;
     }
 
 }

--- a/diffparser/src/test/java/org/wickedsource/diffparser/unified/UnifiedDiffParserTest.java
+++ b/diffparser/src/test/java/org/wickedsource/diffparser/unified/UnifiedDiffParserTest.java
@@ -36,9 +36,9 @@ public class UnifiedDiffParserTest {
 
         Hunk hunk1 = diff1.getHunks().get(0);
         Assert.assertEquals(1, hunk1.getFromFileRange().getLineStart());
-        Assert.assertEquals(4, hunk1.getFromFileRange().getLineEnd());
+        Assert.assertEquals(4, hunk1.getFromFileRange().getLineCount());
         Assert.assertEquals(1, hunk1.getToFileRange().getLineStart());
-        Assert.assertEquals(3, hunk1.getToFileRange().getLineEnd());
+        Assert.assertEquals(3, hunk1.getToFileRange().getLineCount());
 
         List<Line> lines = hunk1.getLines();
         Assert.assertEquals(6, lines.size());


### PR DESCRIPTION
The `Range` class represents a change as an inclusive range of lines: `[start, end]`.  However, per [1], unified format represents a hunk range as the starting line number of the change and the count of lines in the change (which can possibly be zero).  In fact, `UnifiedDiffParser` stores the line counts it reads from the stream as the "line end" in each `Range` it constructs.  Thus, the usage of `Range` internally is inconsistent with its API.  This is also potentially confusing for a library user who may choose to construct a `Diff` programmatically (e.g. for unit testing) and is relying on the Javadocs to describe the model behavior.

This change simply renames all occurrences of "line end" associated with `Range` to "line count" for consistency.

[1] https://en.wikipedia.org/wiki/Diff_utility#Unified_format