### PR TITLE
Force parser to transition to `END` state at end of stream.

### DIFF
--- a/diffparser/src/main/java/org/wickedsource/diffparser/unified/ResizingParseWindow.java
+++ b/diffparser/src/main/java/org/wickedsource/diffparser/unified/ResizingParseWindow.java
@@ -40,6 +40,8 @@ public class ResizingParseWindow implements ParseWindow {
 
     private List<Pattern> ignorePatterns = new ArrayList<>();
 
+    private boolean isEndOfStream = false;
+
     public ResizingParseWindow(InputStream in) {
         Reader unbufferedReader = new InputStreamReader(in);
         this.reader = new BufferedReader(unbufferedReader);
@@ -105,6 +107,21 @@ public class ResizingParseWindow implements ParseWindow {
         while (matchesIgnorePattern(nextLine)) {
             nextLine = reader.readLine();
         }
+
+        return getNextLineOrVirtualBlankLineAtEndOfStream(nextLine);
+    }
+
+    /**
+     * Guarantees that a virtual blank line is injected at the end of the input
+     * stream to ensure the parser attempts to transition to the {@code END}
+     * state, if necessary, when the end of stream is reached.
+     */
+    private String getNextLineOrVirtualBlankLineAtEndOfStream(String nextLine) {
+        if ((nextLine == null) && !isEndOfStream) {
+            isEndOfStream = true;
+            return "";
+        }
+
         return nextLine;
     }
 

--- a/diffparser/src/test/java/org/wickedsource/diffparser/unified/UnifiedDiffParserTest.java
+++ b/diffparser/src/test/java/org/wickedsource/diffparser/unified/UnifiedDiffParserTest.java
@@ -77,4 +77,26 @@ public class UnifiedDiffParserTest {
         Assert.assertEquals(1, hunk1.getFromFileRange().getLineCount());
         Assert.assertEquals(1, hunk1.getToFileRange().getLineCount());
     }
+
+    @Test
+    public void testParse_WhenInputDoesNotEndWithEmptyLine_ShouldTransitionToEndState() throws Exception {
+        // given
+        DiffParser parser = new UnifiedDiffParser();
+        String in = ""
+            + "--- from	2015-12-21 17:53:29.082877088 -0500\n"
+            + "+++ to	2015-12-21 08:41:52.663714666 -0500\n"
+            + "@@ -10,1 +10,1 @@\n"
+            + "-from\n"
+            + "+to\n";
+
+        // when
+        List<Diff> diffs = parser.parse(in.getBytes());
+
+        // then
+        Assert.assertNotNull(diffs);
+        Assert.assertEquals(1, diffs.size());
+
+        Diff diff1 = diffs.get(0);
+        Assert.assertEquals(1, diff1.getHunks().size());
+    }
 }


### PR DESCRIPTION
This solution is short and sweet but smells bad.  It simply injects a virtual blank line at the end of the stream to ensure the parser transitions to the `END` state before returning.