### PR TITLE
Remove extra leading space on neutral lines (fixes #16)

### DIFF
--- a/src/main/java/io/reflectoring/diffparser/api/UnifiedDiffParser.java
+++ b/src/main/java/io/reflectoring/diffparser/api/UnifiedDiffParser.java
@@ -101,7 +101,11 @@ public class UnifiedDiffParser implements DiffParser {
     }
 
     private void parseNeutralLine(Diff currentDiff, String currentLine) {
-        Line line = new Line(Line.LineType.NEUTRAL, currentLine);
+        // Neutral line should have a space as its first character,
+        // however not all tools seem to obey this rule for empty lines (see Tortoise diff),
+        // so let's strip the first character if present.
+        String content = currentLine.substring(Math.min(1, currentLine.length()));
+        Line line = new Line(Line.LineType.NEUTRAL, content);
         currentDiff.getLatestHunk().getLines().add(line);
     }
 

--- a/src/test/java/io/reflectoring/diffparser/unified/GitDiffTest.java
+++ b/src/test/java/io/reflectoring/diffparser/unified/GitDiffTest.java
@@ -47,7 +47,8 @@ public class GitDiffTest {
 
         List<Line> lines = hunk1.getLines();
         assertEquals(8, lines.size());
-        assertEquals(Line.LineType.FROM, lines.get(3).getLineType());
-        assertEquals(Line.LineType.TO, lines.get(4).getLineType());
+        TestUtil.assertLine(lines.get(2), Line.LineType.NEUTRAL, "    <artifactId>diffparser</artifactId>");
+        TestUtil.assertLine(lines.get(3), Line.LineType.FROM, "    <version>1.1-SNAPSHOT</version>");
+        TestUtil.assertLine(lines.get(4), Line.LineType.TO, "    <version>1.0</version>");
     }
 }

--- a/src/test/java/io/reflectoring/diffparser/unified/SvnDiffTest.java
+++ b/src/test/java/io/reflectoring/diffparser/unified/SvnDiffTest.java
@@ -45,10 +45,10 @@ public class SvnDiffTest {
 
         List<Line> lines = hunk1.getLines();
         Assert.assertEquals(16, lines.size());
-        Assert.assertEquals(Line.LineType.TO, lines.get(3).getLineType());
-        Assert.assertEquals(Line.LineType.FROM, lines.get(7).getLineType());
-        Assert.assertEquals(Line.LineType.TO, lines.get(8).getLineType());
-
+        TestUtil.assertLine(lines.get(2), Line.LineType.NEUTRAL, "                case TO_FILE:");
+        TestUtil.assertLine(lines.get(3), Line.LineType.TO, "\t\t\t\t\tnew line");
+        TestUtil.assertLine(lines.get(7), Line.LineType.FROM, "                    parseHunkStart(currentDiff, currentLine);");
+        TestUtil.assertLine(lines.get(8), Line.LineType.TO, "                    changedLine(currentDiff, currentLine);");
     }
 
     @Test

--- a/src/test/java/io/reflectoring/diffparser/unified/TestUtil.java
+++ b/src/test/java/io/reflectoring/diffparser/unified/TestUtil.java
@@ -1,0 +1,17 @@
+package io.reflectoring.diffparser.unified;
+
+import io.reflectoring.diffparser.api.model.Line;
+import junit.framework.Assert;
+
+class TestUtil {
+
+    private TestUtil() {
+        throw new UnsupportedOperationException(getClass().getSimpleName() + " only contains static utility methods " +
+                "and should not be instantiated.");
+    }
+
+    static void assertLine(Line actualLine, Line.LineType expectedType, String expectedContent) {
+        Assert.assertEquals(expectedType, actualLine.getLineType());
+        Assert.assertEquals(expectedContent, actualLine.getContent());
+    }
+}

--- a/src/test/java/io/reflectoring/diffparser/unified/TortoiseDiffTest.java
+++ b/src/test/java/io/reflectoring/diffparser/unified/TortoiseDiffTest.java
@@ -45,13 +45,12 @@ public class TortoiseDiffTest {
 
         List<Line> lines = hunk1.getLines();
         Assert.assertEquals(6, lines.size());
-        Assert.assertEquals(Line.LineType.NEUTRAL, lines.get(0).getLineType());
-        Assert.assertEquals(Line.LineType.FROM, lines.get(1).getLineType());
-        Assert.assertEquals(Line.LineType.TO, lines.get(2).getLineType());
-        Assert.assertEquals(Line.LineType.NEUTRAL, lines.get(3).getLineType());
-        Assert.assertEquals(Line.LineType.FROM, lines.get(4).getLineType());
-        Assert.assertEquals(Line.LineType.NEUTRAL, lines.get(5).getLineType());
-
+        TestUtil.assertLine(lines.get(0), Line.LineType.NEUTRAL, "test1");
+        TestUtil.assertLine(lines.get(1), Line.LineType.FROM, "test1");
+        TestUtil.assertLine(lines.get(2), Line.LineType.TO, "test234");
+        TestUtil.assertLine(lines.get(3), Line.LineType.NEUTRAL, "");
+        TestUtil.assertLine(lines.get(4), Line.LineType.FROM, "test1");
+        TestUtil.assertLine(lines.get(5), Line.LineType.NEUTRAL, " No newline at end of file");
     }
 
     @Test


### PR DESCRIPTION
This removes an extra leading character in a safe manner.